### PR TITLE
Relax Django requirement to 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-Django>=3.2.12
+Django>=3.1


### PR DESCRIPTION
I haven't tested it extensively, but it appears that this package is fully compatible with Django 3.1.  The only changes in this package that I can see, relative to django-background-tasks version 1.2.5, are changes to APIs that are already supported by Django 3.1 (and likely older versions too.)

Therefore, it would be good to relax this requirement so that it's possible to upgrade to this package from `django-background-tasks` without simultaneously upgrading Django itself.
